### PR TITLE
Kill the globalist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,40 @@
 # cli_helper.rb
 
+Notes for Branch kill_the_globalist
+
+As I continue to tweek cli_helper the more it seems to morph into
+a configuration manager that also uses the command line options.
+There are already lots of configuration managers.  Why would I
+want to reinvent this wheel?
+
+IF I wanted to use cli_helper in more complex applications beyond
+the domain of quick and dirty utilities, I would want to remove
+the use of $global variables.  Why?  because of the possibility
+of dirty-fication in concurrent real-threads.
+
+So this branch is to experiment around with different ideas - all
+breaking ideas.
+
+Ought to look at existing configuration managers to see which ones
+will integrate most easily.
+
+What I want from a configuration manager:
+
+`1) full support for the command line with beautiful usage help text
+ 2) support for ENV
+ 3) support for YAML/ERB
+ 4) support for defaults
+
+We start with defaults, trumped by config files, trumped by ENV
+finally trumped by command line options.
+
+This branch may go too far beyound the original intent for cli_help to
+be simple.
+
+
+
+
+
 I had this code just being lazy on my computer.  It might be of use
 to someone else; but, its just really intended to support my own
 quick and dirty command-line based utilities.  Mostly they are one-offs

--- a/cli_helper.gemspec
+++ b/cli_helper.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'slop', "~> 4.0"
-  spec.add_dependency 'hashie'
+  spec.add_dependency 'configatron'
+  spec.add_dependency 'parseconfig'
   spec.add_dependency 'nenv'
   spec.add_dependency 'awesome_print'
   spec.add_dependency 'debug_me'
@@ -35,6 +36,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency 'test_inline'
+  spec.add_development_dependency 'kick_the_tires'
 
 end

--- a/cli_helper.gemspec
+++ b/cli_helper.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'slop', "~> 4.0"
+  spec.add_dependency 'hashie'
   spec.add_dependency 'nenv'
   spec.add_dependency 'awesome_print'
   spec.add_dependency 'debug_me'

--- a/lib/cli_helper.rb
+++ b/lib/cli_helper.rb
@@ -6,24 +6,17 @@
 ##  By:   Dewayne VanHoozer (dvanhoozer@gmail.com)
 #
 
-#require 'test_inline'
-
-# NOTE: this conditional required by test_inline
-if caller.empty?
-  required_by_filename = __FILE__
-else
-  required_by_filename = caller.last.split(':').first
-end
-
 require 'debug_me'
-include DebugMe
+#include DebugMe
 
 require 'awesome_print'
 
 require 'pathname'
 require 'nenv'
+
 require 'slop'
 
+=begin
 # Example Custom Type for Slop
 module Slop
   class PathOption < Option
@@ -47,289 +40,190 @@ module Slop
     #end
   end
 end # module Slop
-
-$cli      = 'a place holder'
-$errors   = []
-$warnings = []
-
-$options = {
-  version:        '0.0.1',# the version of this program
-  arguments:      [],     # whats left after options and parameters are extracted
-  verbose:        false,
-  debug:          false,
-  help:           false,
-  user_name:      Nenv.user || Nenv.user_name || Nenv.logname || 'Dewayne VanHoozer',
-  me:             Pathname.new(required_by_filename).realpath,
-  home_path:      Pathname.new(Nenv.home)
-}
-
-$options[:my_dir]   = $options[:me].parent
-$options[:my_name]  = $options[:me].basename.to_s
-
-# Return full pathname of program
-def me
-  $options[:me]
-end
-
-# Returns the basename of the program as a string
-def my_name
-  $options[:my_name]
-end
-
-# Returns the version of the program as a string
-def version
-  $options[:version]
-end
-
-# Invoke Slop with common CLI parameters and custom
-# parameters provided via a block.  Create '?'
-# for all boolean parameters that have a '--name' flag form.
-# Returns a Slop::Options object
-def cli_helper(my_banner='')
-  param = Slop::Options.new
-
-  if my_banner.empty?
-    param.banner = "Usage: #{my_name} [options] ..."
-  else
-    param.banner = my_banner
-    param.separator "\nUsage: #{my_name} [options] ..."
-  end
-
-  param.separator "\nWhere:"
-  param.separator "  Common Options Are:"
-
-  param.bool '-h', '--help',    'show this message'
-  param.bool '-v', '--verbose', 'enable verbose mode'
-  param.bool '-d', '--debug',   'enable debug mode'
-
-  param.on '--version', "print the version: #{$options[:version]}" do
-    puts $options[:version]
-    exit
-  end
-
-  param.separator "  Program Options Are:"
-
-  yield(param) if block_given?
-
-  parser = Slop::Parser.new(param)
-  $cli = parser.parse(ARGV)
-
-  $options.merge!($cli.to_hash)
-  $options[:arguments] = $cli.arguments
-
-
-  bools = param.options.select do |o|
-    o.is_a? Slop::BoolOption
-  end.select{|o| o.flags.select{|f|f.start_with?('--')}}.
-      map{|o| o.flags.last.gsub('--','')} # SMELL: depends on convention
-
-  bools.each do |m|
-    s = m.to_sym
-    define_method(m+'?') do
-      $options[s]
-    end unless self.respond_to?(m+'?')
-    define_method(m+'!') do
-      $options[s] = true
-    end unless self.respond_to?(m+'!')
-  end
-
-  if help?
-    show_usage
-    exit
-  end
-
-  return param
-end # cli_helper
-
-# Returns the usage/help information as a string
-def usage
-  a_string = $cli.to_s + "\n"
-  a_string += HELP + "\n" if defined?(HELP)
-  return a_string
-end
-
-# Prints to STDOUT the usage/help string
-def show_usage
-  puts usage()
-end
-
-
-# Returns an array of valid files of one type
-def get_pathnames_from(an_array, extnames=['.json', '.txt', '.docx'])
-  an_array = [an_array] unless an_array.is_a? Array
-  extnames = [extnames] unless extnames.is_a? Array
-  extnames = extnames.map{|e| e.downcase}
-  file_array = []
-  an_array.each do |a|
-    pfn = Pathname.new(a)
-    if pfn.directory?
-      file_array << get_pathnames_from(pfn.children, extnames)
-    else
-      file_array << pfn if pfn.exist? && extnames.include?(pfn.extname.downcase)
-    end
-  end
-  return file_array.flatten
-end # def get_pathnames_from(an_array, extname='.json')
-
-
-# Display global warnings and errors arrays and exit if necessary
-def abort_if_errors
-  unless $warnings.empty?
-    STDERR.puts
-    STDERR.puts "The following warnings were generated:"
-    STDERR.puts
-    $warnings.each do |w|
-      STDERR.puts "\tWarning: #{w}"
-    end
-    STDERR.print "\nAbort program? (y/N) "
-    answer = (STDIN.gets).chomp.strip.downcase
-    $errors << "Aborted by user" if answer.size>0 && 'y' == answer[0]
-    $warnings = []
-  end
-  unless $errors.empty?
-    STDERR.puts
-    STDERR.puts "Correct the following errors and try again:"
-    STDERR.puts
-    $errors.each do |e|
-      STDERR.puts "\t#{e}"
-    end
-    STDERR.puts
-    exit(-1)
-  end
-end # def abort_if_errors
-
-# Adds a string to the global $errors array
-def error(a_string)
-  $errors << a_string
-end
-
-# Adds a string to the global $warnings array
-def warning(a_string)
-  $warnings << a_string
-end
-
-
-__END__
-################################################
-## Here is how it works
-
-Test '000 supports basic common parameters' do
-  params = cli_helper
-  assert params.is_a? Slop::Options
-  assert usage.include?('--help')
-  assert usage.include?('--debug')
-  assert usage.include?('--verbose')
-  assert usage.include?('--version')
-  refute usage.include?('--xyzzy')
-end
-
-=begin
-# NOTE: The Test construct creates a dynamic class which
-# does not incorporate 'define_method'  This Test results
-# in errors that are a consequence of the testing framework
-# not the object under test.
-Test '002 creates accessor methods to boolean options' do
-  cli_helper
-  all_methods = methods
-  %w[ help? debug? verbose? version?
-      help! debug! verbose! version!].each do |m|
-    assert all_methods.include?(m)
-  end
-  refute all_methods.include?('xyzzy?')
-  refute all_methods.include?('xyzzy!')
-end
 =end
 
-Test '005 block inclusion' do
-  cli_helper do |param|
-    param.string '-x', '--xyxxy', 'example MAGIC parameter',  default: 'IamDefault'
+require 'hashie'
+
+class CliHelper
+
+  attr_accessor :options
+
+  class Options < Hashie::Mash
+    DEFAULTS = {
+      version:        '0.0.1',# the version of this program
+      arguments:      [],     # whats left after options and parameters are extracted
+      verbose:        false,
+      debug:          false,
+      help:           false,
+      user_name:      Nenv.user || Nenv.user_name || Nenv.logname || 'Dewayne VanHoozer',
+      home_path:      Pathname.new(Nenv.home),
+      cli:            'a place holder for the Slop object',
+      errors:         [],
+      warnings:       []
+    }
+
+    def initialize
+      super(DEFAULTS)
+    end
+
+  end # class Options < Hashie::Mash
+
+  def options
+    @options
   end
-  assert usage.include?('MAGIC')
-end
 
-Test '010 supports banner' do
-  refute usage().include?('BANNER')
-  cli_helper('This is my BANNER')
-  assert usage().include?('BANNER')
-end
-
-Test '015 supports additional help in usage' do
-  refute usage.include?('HELP')
-  HELP = "Do you need some HELP?"
-  assert usage.include?('HELP')
-end
-
-Test '020 put it all together' do
-  cli_helper('This is my BANNER') do |o|
-    o.string '-x', '--xyxxy', 'example MAGIC parameter',  default: 'IamDefault'
+  def initialize
+    @options = Options.new
+    @options.required_by_filename = caller.last.split(':').first
+    @options.me       = Pathname.new(options.required_by_filename).realpath
+    @options.my_dir   = Pathname.new(options.required_by_filename).realpath.parent
+    @options.my_name  = Pathname.new(options.required_by_filename).realpath.basename.to_s
   end
-  HELP = "Do you need some HELP?"
-  assert usage.include?('BANNER')
-  assert usage.include?('MAGIC')
-  assert usage.include?('HELP')
-end
 
-Test '025 Add to $errors' do
-  assert $errors.empty?
-  a_message = 'There is a serious problem here'
-  error a_message
-  refute $errors.empty?
-  assert_equal 1, $errors.size
-  assert_equal a_message, $errors.first
-end
+  # Return full pathname of program
+  def me
+    options.me
+  end
 
-Test '030 Add to $warnings' do
-  assert $warnings.empty?
-  a_message = 'There is a minor problem here'
-  warning a_message
-  refute $warnings.empty?
-  assert_equal 1, $warnings.size
-  assert_equal a_message, $warnings.first
-end
+  # Returns the basename of the program as a string
+  def my_name
+    options.my_name
+  end
 
-Test '035 Add to $errors' do
-  refute $errors.empty?
-  a_message = 'There is another serious problem here'
-  error a_message
-  assert_equal 2, $errors.size
-  assert_equal a_message, $errors.last
-end
+  # Returns the version of the program as a string
+  def version
+    options.version
+  end
 
-Test '040 Add to $warnings' do
-  refute $warnings.empty?
-  a_message = 'There is a another minor problem here'
-  warning a_message
-  assert_equal 2, $warnings.size
-  assert_equal a_message, $warnings.last
-end
+  # Invoke Slop with common CLI parameters and custom
+  # parameters provided via a block.  Create '?'
+  # for all boolean parameters that have a '--name' flag form.
+  # Returns a Slop::Options object
+  def cli_helper(my_banner='')
+    param = Slop::Options.new
+
+    if my_banner.empty?
+      param.banner = "Usage: #{my_name} [options] ..."
+    else
+      param.banner = my_banner
+      param.separator "\nUsage: #{my_name} [options] ..."
+    end
+
+    param.separator "\nWhere:"
+    param.separator "  Common Options Are:"
+
+    param.bool '-h', '--help',    'show this message'
+    param.bool '-v', '--verbose', 'enable verbose mode'
+    param.bool '-d', '--debug',   'enable debug mode'
+
+    param.on '--version', "print the version: #{options.version}" do
+      puts $options[:version]
+      exit
+    end
+
+    param.separator "  Program Options Are:"
+
+    yield(param) if block_given?
+
+    parser = Slop::Parser.new(param)
+    options.cli = parser.parse(ARGV)
+
+    options.merge!(options.cli.to_hash)
+    options.arguments = options.cli.arguments
 
 
+    bools = param.options.select do |o|
+      o.is_a? Slop::BoolOption
+    end.select{|o| o.flags.select{|f|f.start_with?('--')}}.
+        map{|o| o.flags.last.gsub('--','')} # SMELL: depends on convention
+
+=begin
+    bools.each do |m|
+      s = m.to_sym
+      define_method((m+'?').to_sym) do
+        options[s]
+      end unless self.respond_to?((m+'?').to_sym)
+      define_method((m+'!').to_sym) do
+        options[s] = true
+      end unless self.respond_to?((m+'!').to_sym)
+    end
+=end
+
+    if help?
+      show_usage
+      exit
+    end
+
+    return param
+  end # def dewaynelovesella
+  cli_helper
+
+  # Returns the usage/help information as a string
+  def usage
+    a_string = options.cli.to_s + "\n"
+    a_string += HELP + "\n" if defined?(HELP)
+    return a_string
+  end
+
+  # Prints to STDOUT the usage/help string
+  def show_usage
+    puts usage()
+  end
 
 
+  # Returns an array of valid files of one type
+  def get_pathnames_from(an_array, extnames=['.json', '.txt', '.docx'])
+    an_array = [an_array] unless an_array.is_a? Array
+    extnames = [extnames] unless extnames.is_a? Array
+    extnames = extnames.map{|e| e.downcase}
+    file_array = []
+    an_array.each do |a|
+      pfn = Pathname.new(a)
+      if pfn.directory?
+        file_array << get_pathnames_from(pfn.children, extnames)
+      else
+        file_array << pfn if pfn.exist? && extnames.include?(pfn.extname.downcase)
+      end
+    end
+    return file_array.flatten
+  end # def get_pathnames_from(an_array, extname='.json')
 
-Test '999 prints usage()'  do
-  puts
-  puts "="*45
-  show_usage
-  puts "="*45
-  puts
-  a_string = <<EOS
-This is my BANNER
 
-Usage: cli_helper.rb [options] ...
+  # Display global warnings and errors arrays and exit if necessary
+  def abort_if_errors
+    unless $warnings.empty?
+      STDERR.puts
+      STDERR.puts "The following warnings were generated:"
+      STDERR.puts
+      options.warnings.each do |w|
+        STDERR.puts "\tWarning: #{w}"
+      end
+      STDERR.print "\nAbort program? (y/N) "
+      answer = (STDIN.gets).chomp.strip.downcase
+      $errors << "Aborted by user" if answer.size>0 && 'y' == answer[0]
+      $warnings = []
+    end
+    unless $errors.empty?
+      STDERR.puts
+      STDERR.puts "Correct the following errors and try again:"
+      STDERR.puts
+      options.errors.each do |e|
+        STDERR.puts "\t#{e}"
+      end
+      STDERR.puts
+      exit(-1)
+    end
+  end # def abort_if_errors
 
-Where:
-  Common Options Are:
-    -h, --help     show this message
-    -v, --verbose  enable verbose mode
-    -d, --debug    enable debug mode
-    --version      print the version: 0.0.1
-  Program Options Are:
-    -x, --xyxxy    example MAGIC parameter
+  # Adds a string to the global $errors array
+  def error(a_string)
+    options.errors << a_string
+  end
 
-Do you need some HELP?
-EOS
+  # Adds a string to the global $warnings array
+  def warning(a_string)
+    options.warnings << a_string
+  end
 
-  assert_equal a_string, usage
-end
+end # class CliHelper
 

--- a/tests/cli_helper_test.rb
+++ b/tests/cli_helper_test.rb
@@ -3,23 +3,25 @@
 ## Here is how it works
 
 require_relative '../lib/cli_helper'
-c = CliHelper.new
+include CliHelper
 
 
-
+# can not use minitest because it requires pry which
+# requires an older version of slop
 #require 'minitest/autorun'
 require 'kick_the_tires'
+include KickTheTires
 
 #describe 'how it works' do
 
 #it '000 supports basic common parameters' do
-  params = c.cli_helper
+  params = cli_helper
   assert params.is_a? Slop::Options
-  assert c.usage.include?('--help')
-  assert c.usage.include?('--debug')
-  assert c.usage.include?('--verbose')
-  assert c.usage.include?('--version')
-  refute c.usage.include?('--xyzzy')
+  assert usage.include?('--help')
+  assert usage.include?('--debug')
+  assert usage.include?('--verbose')
+  assert usage.include?('--version')
+  refute usage.include?('--xyzzy')
 #end
 
 =begin
@@ -40,22 +42,22 @@ end
 =end
 
 #it '005 block inclusion' do
-  c.cli_helper do |param|
+  cli_helper do |param|
     param.string '-x', '--xyxxy', 'example MAGIC parameter',  default: 'IamDefault'
   end
   assert usage.include?('MAGIC')
 #end
 
 #it '010 supports banner' do
-  refute c.usage().include?('BANNER')
-  c.cli_helper('This is my BANNER')
-  assert c.usage().include?('BANNER')
+  refute usage().include?('BANNER')
+  cli_helper('This is my BANNER')
+  assert usage().include?('BANNER')
 #end
 
 #it '015 supports additional help in usage' do
-  refute c.usage.include?('HELP')
+  refute usage.include?('HELP')
   HELP = "Do you need some HELP?"
-  assert c.usage.include?('HELP')
+  assert usage.include?('HELP')
 #end
 
 #it '020 put it all together' do
@@ -63,43 +65,43 @@ end
     o.string '-x', '--xyxxy', 'example MAGIC parameter',  default: 'IamDefault'
   end
   HELP = "Do you need some HELP?"
-  assert c.usage.include?('BANNER')
-  assert c.usage.include?('MAGIC')
-  assert c.usage.include?('HELP')
+  assert usage.include?('BANNER')
+  assert usage.include?('MAGIC')
+  assert usage.include?('HELP')
 #end
 
 #it '025 Add to options.errors' do
-  assert options.errors.empty?
+  assert configatron.errors.empty?
   a_message = 'There is a serious problem here'
-  c.error a_message
-  refute c.options.errors.empty?
-  assert_equal 1, c.options.errors.size
-  assert_equal a_message, c.options.errors.first
+  error a_message
+  refute configatron.errors.empty?
+  assert_equal 1, configatron.errors.size
+  assert_equal a_message, configatron.errors.first
 #end
 
 #it '030 Add to options.warnings' do
-  assert c.options.warnings.empty?
+  assert configatron.warnings.empty?
   a_message = 'There is a minor problem here'
-  c.warning a_message
-  refute c.options.warnings.empty?
-  assert_equal 1, c.options.warnings.size
-  assert_equal a_message, c.options.warnings.first
+  warning a_message
+  refute configatron.warnings.empty?
+  assert_equal 1, configatron.warnings.size
+  assert_equal a_message, configatron.warnings.first
 #end
 
 #it '035 Add to options.errors' do
-  refute c.options.errors.empty?
+  refute configatron.errors.empty?
   a_message = 'There is another serious problem here'
-  c.error a_message
-  assert_equal 2, c.options.errors.size
-  assert_equal a_message, c.options.errors.last
+  error a_message
+  assert_equal 2, configatron.errors.size
+  assert_equal a_message, configatron.errors.last
 #end
 
 #it '040 Add to options.warnings' do
-  refute c.warnings.empty?
+  refute configatron.warnings.empty?
   a_message = 'There is a another minor problem here'
-  c.warning a_message
-  assert_equal 2, c.options.warnings.size
-  assert_equal a_message, c.options.warnings.last
+  warning a_message
+  assert_equal 2, configatron.warnings.size
+  assert_equal a_message, configatron.warnings.last
 #end
 
 
@@ -109,31 +111,34 @@ end
 #it '888 prints usage()'  do
   puts
   puts "="*45
-  c.show_usage
+  show_usage
   puts "="*45
   puts
   a_string = <<EOS
 This is my BANNER
 
-Usage: cli_helper.rb [options] ...
+Usage: cli_helper_test.rb [options] ...
 
 Where:
+
   Common Options Are:
     -h, --help     show this message
     -v, --verbose  enable verbose mode
     -d, --debug    enable debug mode
     --version      print the version: 0.0.1
+
   Program Options Are:
     -x, --xyxxy    example MAGIC parameter
 
 Do you need some HELP?
 EOS
 
-  assert_equal a_string, c.usage
+  assert_equal a_string, usage
 #end
 
 #it '999 Show the options structure' do
-  ap c.options
+  puts '*'*45
+  ap configatron
 #end
 
 #end # decribe 'how it works'

--- a/tests/cli_helper_test.rb
+++ b/tests/cli_helper_test.rb
@@ -1,0 +1,139 @@
+#!/usr/bin/env ruby
+################################################
+## Here is how it works
+
+require_relative '../lib/cli_helper'
+c = CliHelper.new
+
+
+
+#require 'minitest/autorun'
+require 'kick_the_tires'
+
+#describe 'how it works' do
+
+#it '000 supports basic common parameters' do
+  params = c.cli_helper
+  assert params.is_a? Slop::Options
+  assert c.usage.include?('--help')
+  assert c.usage.include?('--debug')
+  assert c.usage.include?('--verbose')
+  assert c.usage.include?('--version')
+  refute c.usage.include?('--xyzzy')
+#end
+
+=begin
+# NOTE: The Test construct creates a dynamic class which
+# does not incorporate 'define_method'  This Test results
+# in errors that are a consequence of the testing framework
+# not the object under test.
+it '002 creates accessor methods to boolean options' do
+  cli_helper
+  all_methods = methods
+  %w[ help? debug? verbose? version?
+      help! debug! verbose! version!].each do |m|
+    assert all_methods.include?(m)
+  end
+  refute all_methods.include?('xyzzy?')
+  refute all_methods.include?('xyzzy!')
+end
+=end
+
+#it '005 block inclusion' do
+  c.cli_helper do |param|
+    param.string '-x', '--xyxxy', 'example MAGIC parameter',  default: 'IamDefault'
+  end
+  assert usage.include?('MAGIC')
+#end
+
+#it '010 supports banner' do
+  refute c.usage().include?('BANNER')
+  c.cli_helper('This is my BANNER')
+  assert c.usage().include?('BANNER')
+#end
+
+#it '015 supports additional help in usage' do
+  refute c.usage.include?('HELP')
+  HELP = "Do you need some HELP?"
+  assert c.usage.include?('HELP')
+#end
+
+#it '020 put it all together' do
+  cli_helper('This is my BANNER') do |o|
+    o.string '-x', '--xyxxy', 'example MAGIC parameter',  default: 'IamDefault'
+  end
+  HELP = "Do you need some HELP?"
+  assert c.usage.include?('BANNER')
+  assert c.usage.include?('MAGIC')
+  assert c.usage.include?('HELP')
+#end
+
+#it '025 Add to options.errors' do
+  assert options.errors.empty?
+  a_message = 'There is a serious problem here'
+  c.error a_message
+  refute c.options.errors.empty?
+  assert_equal 1, c.options.errors.size
+  assert_equal a_message, c.options.errors.first
+#end
+
+#it '030 Add to options.warnings' do
+  assert c.options.warnings.empty?
+  a_message = 'There is a minor problem here'
+  c.warning a_message
+  refute c.options.warnings.empty?
+  assert_equal 1, c.options.warnings.size
+  assert_equal a_message, c.options.warnings.first
+#end
+
+#it '035 Add to options.errors' do
+  refute c.options.errors.empty?
+  a_message = 'There is another serious problem here'
+  c.error a_message
+  assert_equal 2, c.options.errors.size
+  assert_equal a_message, c.options.errors.last
+#end
+
+#it '040 Add to options.warnings' do
+  refute c.warnings.empty?
+  a_message = 'There is a another minor problem here'
+  c.warning a_message
+  assert_equal 2, c.options.warnings.size
+  assert_equal a_message, c.options.warnings.last
+#end
+
+
+
+
+
+#it '888 prints usage()'  do
+  puts
+  puts "="*45
+  c.show_usage
+  puts "="*45
+  puts
+  a_string = <<EOS
+This is my BANNER
+
+Usage: cli_helper.rb [options] ...
+
+Where:
+  Common Options Are:
+    -h, --help     show this message
+    -v, --verbose  enable verbose mode
+    -d, --debug    enable debug mode
+    --version      print the version: 0.0.1
+  Program Options Are:
+    -x, --xyxxy    example MAGIC parameter
+
+Do you need some HELP?
+EOS
+
+  assert_equal a_string, c.usage
+#end
+
+#it '999 Show the options structure' do
+  ap c.options
+#end
+
+#end # decribe 'how it works'

--- a/tests/cli_helper_test.rb
+++ b/tests/cli_helper_test.rb
@@ -12,6 +12,12 @@ include CliHelper
 require 'kick_the_tires'
 include KickTheTires
 
+require 'debug_me'
+include DebugMe
+
+
+configatron.support_config_files = true
+
 #describe 'how it works' do
 
 #it '000 supports basic common parameters' do
@@ -22,6 +28,13 @@ include KickTheTires
   assert usage.include?('--verbose')
   assert usage.include?('--version')
   refute usage.include?('--xyzzy')
+
+  if configatron.support_config_files
+    assert usage.include?('--config')
+  else
+    refute usage.include?('--config')
+  end
+
 #end
 
 =begin
@@ -133,12 +146,37 @@ Where:
 Do you need some HELP?
 EOS
 
-  assert_equal a_string, usage
+
+a_string_with_config = <<EOS
+This is my BANNER
+
+Usage: cli_helper_test.rb [options] ...
+
+Where:
+
+  Common Options Are:
+    -h, --help     show this message
+    -v, --verbose  enable verbose mode
+    -d, --debug    enable debug mode
+    --version      print the version: 0.0.1
+
+  Program Options Are:
+    -x, --xyxxy    example MAGIC parameter
+    --config       read config file(s) [*.rb, *.yml, *.ini]
+
+Do you need some HELP?
+EOS
+
+  if configatron.support_config_files
+    assert_equal a_string_with_config, usage
+  else
+    assert_equal a_string, usage
+  end
 #end
 
 #it '999 Show the options structure' do
   puts '*'*45
-  ap configatron
+  ap configatron.to_h
 #end
 
 #end # decribe 'how it works'

--- a/tests/config/sample.ini
+++ b/tests/config/sample.ini
@@ -1,0 +1,6 @@
+[base2]
+\  three = 11
+
+[hands]
+  left_hand = 'wedding ring'
+

--- a/tests/config/sample.rb
+++ b/tests/config/sample.rb
@@ -1,0 +1,15 @@
+
+configatron.test do |test|
+  test.host = 'localhost'
+  test.ip   = '127.0.0.1'
+end
+
+configatron.development do |dev|
+  dev.host = 'devhost'
+  dev.ip   = '127.0.0.1'
+end
+
+configatron.production do |prod|
+  prod.host = 'prodhost'
+  prod.ip   = '0.0.0.0'
+end

--- a/tests/config/sample.txt
+++ b/tests/config/sample.txt
@@ -1,0 +1,12 @@
+[base2]
+  zero = 0
+  one = 1
+  two = 10
+
+[fingers]
+  left_hand = 5
+  right_hand = 6
+
+[toes]
+  left_foot = 6
+  right_foot = 5

--- a/tests/config/sample.xyzzy
+++ b/tests/config/sample.xyzzy
@@ -1,0 +1,1 @@
+This is an unknown config file format

--- a/tests/config/sample.yml
+++ b/tests/config/sample.yml
@@ -1,0 +1,16 @@
+---
+test:
+  one: 1
+  two: 1
+  three: 11
+
+development:
+  one: 'one'
+  two: 'two'
+  three: 'three'
+
+production:
+  ones: 1111
+  tows: 2222
+  threes: 'go fish'
+


### PR DESCRIPTION
This is a breaker that removes the $global vars.  It integrates configatron to support access to command line parameters and to config files.  Three types of config files are supported *.rb that make use of the capabilities of configatron, YAML and INI.  The YAML and INI files are passed through ERB before being parsed.

The new --config CLI option allows multiple comma seperated config files to be specified.

A new method #support_config_files was added to enable the --config CLI option.

cli_helper remains a module.  Its expected use is:

``` ruby
require 'cli_helper'
include CliHelper
configatron.version = '1.2.3' # version of 'this' program
chi_helper('Do Some Magic') do |o|
  o.int '-m', '--magic', 'magic number', default: 42
end

print 'The magic number is: ', configatron.magic, "\n"
```
